### PR TITLE
Feature/expiration

### DIFF
--- a/src/main/java/com/xneshi/shrtnurl/model/Url.java
+++ b/src/main/java/com/xneshi/shrtnurl/model/Url.java
@@ -22,4 +22,5 @@ public class Url {
   private String originalUrl;
   private String shortCode;
   private LocalDateTime createdAt;
+  private LocalDateTime expiresAt;
 }

--- a/src/main/java/com/xneshi/shrtnurl/respository/UrlRepository.java
+++ b/src/main/java/com/xneshi/shrtnurl/respository/UrlRepository.java
@@ -5,8 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.rmi.server.UID;
+import java.time.LocalDateTime;
 
 @Repository
 public interface UrlRepository extends JpaRepository<Url, UID> {
   Url findByShortCode(String shortCode);
+  void deleteAllByExpiresAtBefore(LocalDateTime expiresAt);
 }

--- a/src/main/java/com/xneshi/shrtnurl/service/UrlService.java
+++ b/src/main/java/com/xneshi/shrtnurl/service/UrlService.java
@@ -7,6 +7,7 @@ import com.xneshi.shrtnurl.model.Url;
 import com.xneshi.shrtnurl.respository.UrlRepository;
 import com.xneshi.shrtnurl.util.ShortenerUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -20,6 +21,7 @@ public class UrlService {
     var shortenedUrl = UrlMapper.toUrl(url);
     shortenedUrl.setCreatedAt(LocalDateTime.now());
     shortenedUrl.setShortCode(ShortenerUtil.hashUrl(url.originalUrl()));
+    shortenedUrl.setExpiresAt(LocalDateTime.now().plusDays(30));
     urlRepository.save(shortenedUrl);
 
     return UrlMapper.toUrlResponseDTO(shortenedUrl);
@@ -28,5 +30,10 @@ public class UrlService {
   public String findOriginalUrl(String shortCode) {
     Url url = urlRepository.findByShortCode(shortCode);
     return url.getOriginalUrl();
+  }
+
+  @Scheduled(cron = "0 0 0 * * *")
+  public void expireUrls() {
+    urlRepository.deleteAllByExpiresAtBefore(LocalDateTime.now());
   }
 }


### PR DESCRIPTION
This pull request introduces functionality to handle URL expiration in the `shrtnurl` application. The changes include adding an expiration date to URLs, implementing scheduled cleanup for expired URLs, and updating the relevant repository and service methods.

### URL expiration functionality:

* **Added expiration date to URLs**: Introduced the `expiresAt` field in the `Url` model to store the expiration date of each shortened URL.
* **Scheduled cleanup of expired URLs**: Added a `@Scheduled` method in `UrlService` to periodically delete expired URLs from the database using the new repository method. The cleanup runs daily at midnight.

### Repository updates:

* **New repository method for expiration cleanup**: Added `deleteAllByExpiresAtBefore(LocalDateTime expiresAt)` to `UrlRepository` for removing expired URLs.

### Service updates:

* **Set expiration date during URL shortening**: Updated the `shortenUrl` method in `UrlService` to set the `expiresAt` field to 30 days from the creation date.