### PR TITLE
Added customized logic

### DIFF
--- a/src/main/java/com/xneshi/shrtnurl/dto/UrlRequestDTO.java
+++ b/src/main/java/com/xneshi/shrtnurl/dto/UrlRequestDTO.java
@@ -1,9 +1,12 @@
 package com.xneshi.shrtnurl.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record UrlRequestDTO(
     @NotBlank
-    String originalUrl
+    String originalUrl,
+    @Size(max = 16)
+    String customizedName
 ) {
 }

--- a/src/main/java/com/xneshi/shrtnurl/service/UrlService.java
+++ b/src/main/java/com/xneshi/shrtnurl/service/UrlService.java
@@ -20,8 +20,14 @@ public class UrlService {
   public UrlResponseDTO shortenUrl(UrlRequestDTO url) {
     var shortenedUrl = UrlMapper.toUrl(url);
     shortenedUrl.setCreatedAt(LocalDateTime.now());
-    shortenedUrl.setShortCode(ShortenerUtil.hashUrl(url.originalUrl()));
     shortenedUrl.setExpiresAt(LocalDateTime.now().plusDays(30));
+
+    if (url.customizedName() != null && !url.customizedName().isBlank()) {
+      shortenedUrl.setShortCode(url.customizedName());
+    } else {
+      shortenedUrl.setShortCode(ShortenerUtil.hashUrl(url.originalUrl()));
+    }
+
     urlRepository.save(shortenedUrl);
 
     return UrlMapper.toUrlResponseDTO(shortenedUrl);


### PR DESCRIPTION
This pull request introduces support for customized short URLs in the URL shortening service. The changes include updates to the `UrlRequestDTO` to allow specifying a custom name for the short URL and modifications to the `UrlService` logic to prioritize using the custom name if provided.

### Enhancements to URL customization:

* **DTO Update**: Added a new field `customizedName` with a maximum size constraint of 16 characters to the `UrlRequestDTO` class. This allows users to specify a custom name for the shortened URL. (`src/main/java/com/xneshi/shrtnurl/dto/UrlRequestDTO.java`, [src/main/java/com/xneshi/shrtnurl/dto/UrlRequestDTO.javaR4-R10](diffhunk://#diff-20475371f3e2875b2dcf03adefc88183f9220f28c7a496a634007a1d64773901R4-R10))

* **Service Logic Update**: Modified the `shortenUrl` method in `UrlService` to check if a `customizedName` is provided. If it is valid, the service uses it as the short code; otherwise, it falls back to generating a hash from the original URL. (`src/main/java/com/xneshi/shrtnurl/service/UrlService.java`, [src/main/java/com/xneshi/shrtnurl/service/UrlService.javaL23-R30](diffhunk://#diff-8d6e1052d8e4f48ce8c130f68ea25106b8186631e3ef90cab210ba75c2a4795dL23-R30))